### PR TITLE
Added Typescript correct typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,6 +1,60 @@
-// This is outdated
-export interface _VueStripeCheckout {
-  install: (Vue: any, options?: any) => void
+import Vue, { PluginObject, PluginFunction } from "vue";
+
+export type StripePluginOptions = {
+  pk: string;
+  stripeAccount: string;
+  apiVersion: string;
+  locale: string;
 }
-export declare const VueStripeCheckout: _VueStripeCheckout;
-export default VueStripeCheckout;
+
+export interface StripePluginObject extends PluginObject<StripePluginOptions> {
+  install: PluginFunction<StripePluginOptions>;
+}
+
+export declare const StripePlugin: StripePluginObject;
+
+export class StripeCheckout extends Vue {
+  pk: string;
+  mode?: string;
+  lineItems: Array<any> | null;
+  items: Array<any> | null;
+  successUrl: string;
+  cancelUrl: string;
+  submitType?: string;
+  billingAddressCollection: string;
+  clientReferenceId: string;
+  customerEmail?: string;
+  sessionId?: string;
+  locale: string;
+  shippingAddressCollection?: any;
+  disableAdvancedFarudDetection: boolean;
+
+  redirectToCheckout(): void;
+}
+
+export type StripeElementsPluginOptions = {
+  pk: string;
+  stripeAccount: string;
+  apiVersion: string;
+  locale: string;
+  elementsOptions: any;
+}
+
+export interface StripeElementsPluginObject extends PluginObject<StripeElementsPluginOptions> {
+  install: PluginFunction<StripeElementsPluginOptions>;
+}
+
+export declare const StripeElementsPlugin: StripePluginObject;
+
+export class StripeElementsCard extends Vue {
+  pk: string;
+  stripeAccount: string;
+  apiVersion: string;
+  locale: string;
+  elementsOptions: any;
+  disableAdvancedFraudDetection: boolean;
+  classes: any;
+  elementStyle: any;
+  value?: string;
+  hidePostalCode: boolean;
+}


### PR DESCRIPTION
Fixes vue-stripe/vue-stripe#110

This commit adds the correct typescript typings for the package

ElementOptions and other nested objects are just declared as "any" type, because connected with StripeElements library and I don't want to add an extra dep just for typings